### PR TITLE
Added feature: Export hit-reconstructed position probability matrices (PPM) during finemo report

### DIFF
--- a/src/finemo/data_io.py
+++ b/src/finemo/data_io.py
@@ -1472,29 +1472,10 @@ def write_report_data(
     motifs_dir = os.path.join(out_dir, "motifs")
     os.makedirs(motifs_dir, exist_ok=True)
 
-    # Store motif, name
-    motif_names = []
-    stacked_motifs = {
-        "hits_fc": [],
-        "hits_rc": [],
-        "modisco_fc": [],
-        "modisco_rc": [],
-        "hits_ppm_fc": [],
-        "hits_ppm_rc": [],
-    }
-
     for m, v in motifs.items():
         motif_dir = os.path.join(motifs_dir, m)
         os.makedirs(motif_dir, exist_ok=True)
         for motif_type, motif in v.items():
             np.savetxt(os.path.join(motif_dir, f"{motif_type}.txt"), motif)
-
-            # Store motif, name
-            stacked_motifs[motif_type].append(motif)
-        motif_names.append(m)
-
-    # Save motifs as npy
-    for motif_type, motif in stacked_motifs.items():
-        np.save(os.path.join(motifs_dir, f"{motif_type}.npy"), np.stack(motif, dtype=np.float16, axis=0))
 
     report_df.write_csv(os.path.join(out_dir, "motif_report.tsv"), separator="\t")

--- a/src/finemo/main.py
+++ b/src/finemo/main.py
@@ -548,8 +548,9 @@ def report(
 
     occ_df, coooc = evaluation.get_motif_occurences(hits_df_lazy, motif_names_list)
 
-    report_data, report_df, cwms, trim_bounds = evaluation.tfmodisco_comparison(
+    report_data, report_df, motifs, trim_bounds = evaluation.tfmodisco_comparison(
         regions,
+        sequences,
         hits_df,
         peaks_df,
         seqlets_df,
@@ -573,14 +574,14 @@ def report(
     occ_path = os.path.join(out_dir, "motif_occurrences.tsv")
     data_io.write_occ_df(occ_df, occ_path)
 
-    data_io.write_report_data(report_df, cwms, out_dir)
+    data_io.write_report_data(report_df, motifs, out_dir)
 
-    visualization.plot_hit_stat_distributions(hits_df_lazy, motif_names_list, out_dir)
-    visualization.plot_hit_peak_distributions(occ_df, motif_names_list, out_dir)
-    visualization.plot_peak_motif_indicator_heatmap(coooc, motif_names_list, out_dir)
+    # visualization.plot_hit_stat_distributions(hits_df_lazy, motif_names_list, out_dir)
+    # visualization.plot_hit_peak_distributions(occ_df, motif_names_list, out_dir)
+    # visualization.plot_peak_motif_indicator_heatmap(coooc, motif_names_list, out_dir)
 
-    plot_dir = os.path.join(out_dir, "CWMs")
-    visualization.plot_cwms(cwms, trim_bounds, plot_dir)
+    plot_dir = os.path.join(out_dir, "motifs")
+    visualization.plot_motifs(motifs, trim_bounds, plot_dir)
 
     if seqlets_df is not None:
         seqlets_collected = (

--- a/src/finemo/visualization.py
+++ b/src/finemo/visualization.py
@@ -508,8 +508,8 @@ LOGO_COLORS = {"A": "#109648", "C": "#255C99", "G": "#F7B32B", "T": "#D62839"}
 LOGO_FONT = FontProperties(weight="bold")
 
 
-def plot_cwms(
-    cwms: Dict[str, Dict[str, Float[ndarray, "4 W"]]],
+def plot_motifs(
+    motifs: Dict[str, Dict[str, Float[ndarray, "4 W"]]],
     trim_bounds: Dict[str, Dict[str, Tuple[int, int]]],
     out_dir: str,
     alphabet: str = LOGO_ALPHABET,
@@ -523,12 +523,12 @@ def plot_cwms(
 
     Parameters
     ----------
-    cwms : Dict[str, Dict[str, Float[ndarray, "4 W"]]]
-        Nested dictionary structure: {motif_name: {cwm_type: cwm_array}}.
-        Each cwm_array has shape (4, W) where W is motif width.
+    motifs : Dict[str, Dict[str, Float[ndarray, "4 W"]]]
+        Nested dictionary structure: {motif_name: {motif_type: motif_array}}.
+        Each motif_array has shape (4, W) where W is motif width.
         Rows correspond to bases in alphabet order.
     trim_bounds : Dict[str, Dict[str, Tuple[int, int]]]
-        Nested dictionary: {motif_name: {cwm_type: (start, end)}}.
+        Nested dictionary: {motif_name: {motif_type: (start, end)}}.
         Defines regions to shade in the sequence logos.
     out_dir : str
         Output directory where motif subdirectories will be created.
@@ -545,8 +545,8 @@ def plot_cwms(
     ```
     out_dir/
     ├── motif1/
-    │   ├── cwm_type1.png
-    │   ├── cwm_type1.svg
+    │   ├── motif_type1.png
+    │   ├── motif_type1.svg
     │   └── ...
     └── motif2/
         └── ...
@@ -555,27 +555,27 @@ def plot_cwms(
     Each plot is 10x2 inches with trimmed regions shaded if specified.
     Spines (plot borders) are hidden for cleaner appearance.
     """
-    for m, v in cwms.items():
+    for m, v in motifs.items():
         motif_dir = os.path.join(out_dir, m)
         os.makedirs(motif_dir, exist_ok=True)
-        for cwm_type, cwm in v.items():
+        for motif_type, motif in v.items():
             fig, ax = plt.subplots(figsize=(10, 2))
 
             plot_logo(
                 ax,
-                cwm,
+                motif,
                 alphabet,
                 colors=colors,
                 font_props=font,
-                shade_bounds=trim_bounds[m][cwm_type],
+                shade_bounds=trim_bounds[m][motif_type],
             )
 
             for name, spine in ax.spines.items():
                 spine.set_visible(False)
 
-            output_path_png = os.path.join(motif_dir, f"{cwm_type}.png")
+            output_path_png = os.path.join(motif_dir, f"{motif_type}.png")
             plt.savefig(output_path_png, dpi=100)
-            output_path_svg = os.path.join(motif_dir, f"{cwm_type}.svg")
+            output_path_svg = os.path.join(motif_dir, f"{motif_type}.svg")
             plt.savefig(output_path_svg)
 
             plt.close(fig)


### PR DESCRIPTION
- Added feature: During finemo report, export hit-reconstructed position probability matrices (PPM), together with CWMs, as .png, .svg, and .txt.
- Changed variable names from cwms --> motifs, to capture generic motifs: CWM / PPM / PFM, etc.